### PR TITLE
Linux compat

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ esp:
 	echo "Run: import ngu_tests.run"
 
 quick:
-	make -f Makefile.unix
+	make -f makefile.unix
 	(cd ngu/ngu_tests; make)
 	./ngu-micropython -c 'import ngu_tests.run'
 

--- a/ngu/random.c
+++ b/ngu/random.c
@@ -30,9 +30,14 @@ extern uint32_t rng_get(void);
 # endif
 #endif
 
-#ifdef UNIX
+#if defined(__APPLE__) || defined(__FreeBSD__)
 # define CHIP_TRNG_SETUP()      
 # define CHIP_TRNG_32()         arc4random()
+#endif
+
+#ifdef __linux__
+# define CHIP_TRNG_SETUP()
+# define CHIP_TRNG_32()         random()
 #endif
 
 #ifndef CHIP_TRNG_SETUP


### PR DESCRIPTION
* add linux compatibility
* fix Makefile typo

Currently libs like HWI use git patches to make libngu work on linux (so they are able tu run coldcard simulator) - this can make it work out of the box.