### PR TITLE
compact seed

### DIFF
--- a/ngu/bip39.py
+++ b/ngu/bip39.py
@@ -293,6 +293,27 @@ _lookup = {'a':0, 'ab':0, 'ac':10, 'ad':24, 'ae':33, 'af':34, 'ag':37, 'ah':41, 
 'ye':2039, 'yo':2041, 'z':2044, 'ze':2044, 'zo':2046} # 225 entries
 
 
+def get_word_index(word):
+    # expectation is that this is faster than iterable.index()
+    # input string word; return int index in wordlist
+    # also accepts just first four distinctive characters of the word (if len > 4)
+    
+    if not (3 < len(word) < 8):
+        raise ValueError(word)
+	
+    try:
+    	# first two letters must be right
+        start_index = _lookup[word[:2]]
+    except KeyError:
+	raise ValueError(word)
+
+    for i, w in enumerate(wordlist_en[start_index:], start=start_index):
+        if word == w or word == w[:4]:
+            return i
+    else:
+        raise ValueError(word)
+
+
 def b2a_words(msg):
     "map binary to words, including a few bits of checksum, per BIP39 spec"
     l = len(msg)
@@ -332,11 +353,7 @@ def _split_lookup(phrase):
 
     rv = 0
     for w in phrase:
-        try:
-            idx = wordlist_en.index(w)
-        except ValueError:
-            raise ValueError(w)
-
+        idx = get_word_index(w)
         rv = (rv << 11) | idx
 
     return num, rv
@@ -434,6 +451,6 @@ def master_secret(words, pw=b''):
         import ngu
         return ngu.hash.pbkdf2_sha512(words, salt, 2048)
     except ImportError:
-        import wallycore 
+        import wallycore
         return wallycore.pbkdf2_hmac_sha512(words, salt, 0, 2048)
 

--- a/ngu/ngu_tests/test_bip39.py
+++ b/ngu/ngu_tests/test_bip39.py
@@ -28,9 +28,14 @@ import bip39
 from ngu_tests import b39_data
 from ngu_tests import b39_vectors
 
+def seed_compact_form(seed_words):
+    return " ".join([w[:4] for w in seed_words.split(" ")])
+
 def test_vectors():
     for raw, words, ms, _ in b39_vectors.english[0:10]:
-        assert bip39.a2b_words(words) == a2b_hex(raw)
+        target = a2b_hex(raw)
+        assert bip39.a2b_words(words) == target
+        assert bip39.a2b_words(seed_compact_form(words)) == target
         got = bip39.master_secret(words.encode('utf'), a2b_hex('5452455a4f52'))
         assert got == a2b_hex(ms)
         
@@ -43,7 +48,9 @@ def test_b2a():
 def test_a2b():
     for value, words in b39_data.vectors:
         got = bip39.a2b_words(words)
+        got_compact = bip39.a2b_words(seed_compact_form(words))
         assert got == value
+        assert got_compact == value
 
 def test_guessing():
     for value, words in b39_data.vectors:


### PR DESCRIPTION
* add ability to parse seed in compact form (first 4 letters if word len > 4)
* method `get_word_index` is approximately 3x slower than builtin `iterable.index`. This depends mostly on the position of the word in the list. Further the word is in the list `get_word_index` performance compared to builtin index increases (builtin index iterates from element 0 every time).
* for example parsing 100 random generated seeds (with whole words) builtin index performs in cca 113ms and  `get_word_index` in cca 300ms. This makes  `get_word_index` cca 200ms slower for 100 seeds.

I think the performance sacrifice is reasonable here.