### PR TITLE
fix v0.3.0 fo CC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@ tags:
 test tests:
 	(cd ngu/ngu_tests; make tests)
 
+# DEVELOPER NOTE
+# adjusting values in secp256k1 configure must match ngu/lib_secp256k1.c (after v0.3.0)
 K1_CONF_FLAGS = --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-module-recovery
 
 .PHONY: one-time

--- a/ngu/lib_secp256k1.c
+++ b/ngu/lib_secp256k1.c
@@ -1,12 +1,31 @@
 #ifndef NO_QSTR
 
-# define USE_EXTERNAL_DEFAULT_CALLBACKS
+/* DEVELOPER NOTE */
+/* This MUST match what is passed to configure in Makefile via K1_CONF_FLAGS */
+/* This is a reaction to v0.3.0 and removal of configuration header */
+/* https://github.com/bitcoin-core/secp256k1/blob/master/CHANGELOG.md#removed */
+
+/* Set ecmult gen precision bits */
+#define ECMULT_GEN_PREC_BITS 2
+
+/* Set window size for ecmult precomputation */
+#define ECMULT_WINDOW_SIZE 2
+
+/* Define this symbol to enable the ECDH module */
+#define ENABLE_MODULE_ECDH 1
+
+/* Define this symbol to enable the extrakeys module */
+#define ENABLE_MODULE_EXTRAKEYS 1
+
+/* Define this symbol to enable the ECDSA pubkey recovery module */
+#define ENABLE_MODULE_RECOVERY 1
+
+/* Define this symbol to enable the schnorrsig module */
+#define ENABLE_MODULE_SCHNORRSIG 1
+
+#define USE_EXTERNAL_DEFAULT_CALLBACKS
 
 # include "src/secp256k1.c"
-# include "src/modules/extrakeys/main_impl.h"
-# include "src/modules/schnorrsig/main_impl.h"
-# include "src/modules/recovery/main_impl.h"
-# include "src/modules/ecdh/main_impl.h"
 # include "src/precomputed_ecmult.c"
 # include "src/precomputed_ecmult_gen.c"
 #endif


### PR DESCRIPTION
* better cope with removal of configuration header in secp256k1 `v0.3.0`
* still not sure if this is the best way to cope with removal of config header, but at least I can build CC with this

Error building CC:
```
arm-none-eabi-ld: build-COLDCARD_MK4/firmware.elf section `.text' will not fit in region `FLASH_TEXT'
arm-none-eabi-ld: region `FLASH_TEXT' overflowed by 566412 bytes
```

Seems like including those header files in `ngu/lib_secp256k1.c` picks much more (unnecessary) code...