### PR TITLE
bug: replace memcpy of keypair in `keypair.xonly_tweak_add(`

### DIFF
--- a/ngu/k1.c
+++ b/ngu/k1.c
@@ -515,9 +515,12 @@ STATIC mp_obj_t s_keypair_xonly_tweak_add(mp_obj_t self_in, mp_obj_t tweak32_in)
     mp_obj_keypair_t *rv = m_new_obj(mp_obj_keypair_t);
     rv->base.type = &s_keypair_type;
 
-    memcpy(&rv->keypair, &self->keypair, sizeof(s_keypair_type));
-
     sec_setup_ctx();
+
+    int key_ok = secp256k1_keypair_create(lib_ctx, &rv->keypair, self->privkey);
+    if(key_ok != 1) {
+        mp_raise_ValueError(MP_ERROR_TEXT("secp256k1_keypair_xonly_tweak_add secp256k1_keypair_create"));
+    }
 
     int ok = secp256k1_keypair_xonly_tweak_add(lib_ctx, &rv->keypair, tweak32.buf);
     if(ok != 1) {


### PR DESCRIPTION
* using `memcpy` over keypair struct does not work in stm32 build
* works fine in unix build
* replace with keypair creation from secret key
* this bug caused that using `sign_schnorr` with tweaked keypair instead of raw secret key does not work - without this bug patched, users MUST only use `sign_schnorr` with raw secret key on stm32.