### PR TITLE
bump secp256k1 to `v0.5.0`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ test tests:
 
 # DEVELOPER NOTE
 # adjusting values in secp256k1 configure must match ngu/lib_secp256k1.c (after v0.3.0)
-K1_CONF_FLAGS = --with-ecmult-window=2 --with-ecmult-gen-precision=2 --enable-module-recovery
+K1_CONF_FLAGS = --with-ecmult-window=2 --with-ecmult-gen-kb=2 --enable-module-recovery
 
 .PHONY: one-time
 one-time:

--- a/ngu/lib_secp256k1.c
+++ b/ngu/lib_secp256k1.c
@@ -6,7 +6,7 @@
 /* https://github.com/bitcoin-core/secp256k1/blob/master/CHANGELOG.md#removed */
 
 /* Set ecmult gen precision bits */
-#define ECMULT_GEN_PREC_BITS 2
+#define ECMULT_GEN_KB 2
 
 /* Set window size for ecmult precomputation */
 #define ECMULT_WINDOW_SIZE 2


### PR DESCRIPTION
* smaller and faster secp256k1 version
* unix port proof (with `EXCLUDE_NGU_TESTS`):

with secp v0.5.0:
```
1441721   93644   11704 1547069  179b3d ngu-micropython
-rwxrwxr-x 1 scg scg 1542536 máj 12 14:33 libs/mpy/ports/unix/ngu-micropython
```
with secp v0.3.0 (current libngu master)
```
1453801   93644   11704 1559149  17ca6d ngu-micropython
-rwxrwxr-x 1 scg scg 1554824 máj 12 14:39 libs/mpy/ports/unix/ngu-micropython
```
Based on this line from [ChangeLog](https://github.com/bitcoin-core/secp256k1/blob/master/CHANGELOG.md#050---2024-05-06) `This changes the supported precomputed table sizes for these operations. The new supported sizes are 2 KiB, 22 KiB, or 86 KiB (while the old supported sizes were 32 KiB, 64 KiB, or 512 KiB).` I would expect size saving about 30Kib but I can only see half of it in resulting mpy. Maybe block size?

Based on below simple test we can also see speed performance improvements:
```
>>> import ngu, utime
>>> def timeit():
...     start_time = utime.ticks_ms()
...     for i in range(100, 201):
...         sec = md = bytes([i]) * 32
...         pair = ngu.secp256k1.keypair(sec)
...         pair.pubkey()
...         ngu.secp256k1.sign(pair, md, 0)
...     end_time = utime.ticks_ms()
...     return utime.ticks_diff(end_time, start_time)


>>> c = 0
>>> n = 1000
>>> for i in range(n):
...     c += timeit()
...     
...     
>>> c / n
#
# 76.594    for v0.5.0
# 130.288  for v0.3.0
```
Speed wise I can see 40% improvement.