### PR TITLE
raise `ECMULT_WINDOW_SIZE` 2 --> 8 for faster key derivation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,10 @@ test tests:
 # DEVELOPER NOTE
 # These must match the table-size #defines in ngu/lib_secp256k1.c (after v0.3.0 the
 # amalgamation build is driven by those defines, NOT by these flags; these only control
-# `make precomp` table regeneration). gen-kb=22: secp256k1 default & fastest signing
-# point (== COMB_BLOCKS=11/COMB_TEETH=6).
-K1_CONF_FLAGS = --with-ecmult-window=2 --with-ecmult-gen-kb=22 --enable-module-recovery
+# `make precomp` table regeneration).
+# gen-kb=22: secp256k1 default & fastest signing point (== COMB_BLOCKS=11/COMB_TEETH=6)
+# window=8: faster pubkey derivation/verify (+8KB flash)
+K1_CONF_FLAGS = --with-ecmult-window=8 --with-ecmult-gen-kb=22 --enable-module-recovery
 
 .PHONY: one-time
 one-time:

--- a/ngu/lib_secp256k1.c
+++ b/ngu/lib_secp256k1.c
@@ -11,8 +11,10 @@
 #define COMB_BLOCKS 11
 #define COMB_TEETH 6
 
-/* Set window size for ecmult precomputation */
-#define ECMULT_WINDOW_SIZE 2
+/* Window for the general ecmult table (secp256k1_pre_g). Governs the BIP-32 *public*
+   key derivation hot path (pubkey_tweak_add) as well as ECDSA/Schnorr verify and MuSig.
+   8 == ~29% faster public derivation than 2, for +8KB flash */
+#define ECMULT_WINDOW_SIZE 8
 
 /* Define this symbol to enable the ECDH module */
 #define ENABLE_MODULE_ECDH 1


### PR DESCRIPTION
`ECMULT_WINDOW_SIZE` sizes the general secp256k1_ecmult table (secp256k1_pre_g), which backs every variable-base multiply: BIP-32 public (xpub) derivation (pubkey_tweak_add), ECDSA/Schnorr verify, pubkey recovery, and MuSig tweaks. Raising it 2→8 trades a little flash for materially faster derivation. Signing is unaffected — it uses ecmult_gen - a separate code path.

Flash cost: +8,064 B

Public key derivation (deriving public key from public key) shows 25-30% speed-up. Deriving pubkey from private key is unaffected (as it uses ecmult_gen).