### PR TITLE
Enforce HW TRNG

### DIFF
--- a/ngu/random.c
+++ b/ngu/random.c
@@ -25,7 +25,7 @@ extern uint32_t rng_get(void);
 # define CHIP_TRNG_SETUP()      
 # define CHIP_TRNG_32()         rng_get()
 
-# ifndef MICROPY_HW_ENABLE_RNG
+# if MICROPY_HW_ENABLE_RNG == 0
 # error "get a HW TRNG plz"
 # endif
 #endif


### PR DESCRIPTION
Enforce HW TRNG to avoid an issue similar to https://engineering.block.xyz/blog/predictable-rng-fallback-and-32-bit-reseed-in-coldcard-firmware in the future 

You don't know me but this should be easy enough to validate :)