### PR TITLE
fix: absorb full-width entropy in random.reseed()

### DIFF
--- a/ngu/ngu_tests/test_random.py
+++ b/ngu/ngu_tests/test_random.py
@@ -30,9 +30,21 @@ for mx in range(10, 2000, 73):
     print(" => %.0f %%" % covered)
     assert covered >= 97        # maybe bad luck
 
-# api test only; can't verify results
-ngu.random.reseed(123)
+# api test only; can't verify results (public output is XOR-masked with the
+# chip TRNG, so the reseeded Yasmarang stream is not observable from here)
+ngu.random.reseed(123)                       # legacy int arg still accepted
 ngu.random.reseed(456)
 ngu.random.reseed(0xffff_ffff)
+
+# regression: reseed() must accept a full-width (digest) seed, not just 32 bits.
+# The historic bug fed only n[0:4] into reseed(); guard that the full digest is
+# a valid argument so a caller can hand over all of its entropy.
+ngu.random.reseed(bytes(range(32)))          # 32-byte digest (bytes)
+ngu.random.reseed(bytearray(b'\xa5' * 32))   # bytes-like (bytearray)
+ngu.random.reseed(b'\x01\x02\x03\x04\x05\x06\x07\x08')   # SE-sized minimum
+# generator keeps producing well-distributed output after a full-width reseed
+after = [ngu.random.uint32() for _ in range(1000)]
+assert len(after) == len(set(after)), 'bad luck, try again'
+assert max(after) > 0x80000000 and min(after) < 0x80000000
 
 print('PASS - test_random')

--- a/ngu/ngu_tests/test_random.py
+++ b/ngu/ngu_tests/test_random.py
@@ -42,6 +42,12 @@ ngu.random.reseed(0xffff_ffff)
 ngu.random.reseed(bytes(range(32)))          # 32-byte digest (bytes)
 ngu.random.reseed(bytearray(b'\xa5' * 32))   # bytes-like (bytearray)
 ngu.random.reseed(b'\x01\x02\x03\x04\x05\x06\x07\x08')   # SE-sized minimum
+# an empty seed must be rejected, not silently ignored (no-op reseed)
+try:
+    ngu.random.reseed(b'')
+    raise AssertionError('empty seed was accepted')
+except ValueError:
+    pass
 # generator keeps producing well-distributed output after a full-width reseed
 after = [ngu.random.uint32() for _ in range(1000)]
 assert len(after) == len(set(after)), 'bad luck, try again'

--- a/ngu/random.c
+++ b/ngu/random.c
@@ -161,7 +161,52 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_bytes_obj, random_bytes);
 
 STATIC mp_obj_t random_reseed(mp_obj_t arg)
 {
-    yasmarang_pad = mp_obj_get_int_truncated(arg);
+    // Absorb ALL of the supplied entropy into ALL generator state words.
+    //
+    // The previous implementation did `yasmarang_pad = int(arg)`, which
+    //   (a) kept only the low 32 bits of whatever was passed in, and
+    //   (b) never touched yasmarang_n / _d / _dat (left at fixed constants),
+    // so after reseeding the entire generator was a pure function of a single
+    // 32-bit word -> a 2**32 state space. When the on-chip TRNG is biased or
+    // backdoored this reseed is the only independent entropy, so its width is
+    // the wallet's real security margin. Feed the full digest, not 4 bytes.
+    //
+    // Accepts a bytes-like object (preferred) or, for backward compatibility
+    // with existing callers/tests, a plain integer.
+
+    uint8_t tmp[4];
+    const uint8_t *p;
+    size_t len;
+
+    mp_buffer_info_t buf;
+    if(mp_get_buffer(arg, &buf, MP_BUFFER_READ)) {
+        p = (const uint8_t *)buf.buf;
+        len = buf.len;
+    } else {
+        uint32_t v = mp_obj_get_int_truncated(arg);
+        tmp[0] = (uint8_t)(v);
+        tmp[1] = (uint8_t)(v >> 8);
+        tmp[2] = (uint8_t)(v >> 16);
+        tmp[3] = (uint8_t)(v >> 24);
+        p = tmp;
+        len = sizeof(tmp);
+    }
+
+    // Sponge-style absorb: fold each byte across the independent state words
+    // (yasmarang_n is re-derived from _pad on every step, so seeding _pad, _d
+    // and _dat covers the whole state), stepping the generator between bytes so
+    // that early input diffuses into every subsequent output.
+    for(size_t i = 0; i < len; i++) {
+        yasmarang_pad ^= (uint32_t)p[i] << ((i & 3) * 8);
+        yasmarang_d   += (uint32_t)p[i] * 0x01000193u;      // spread across 32 bits
+        yasmarang_dat ^= p[i];
+        (void)my_yasmarang();
+    }
+
+    // Final diffusion rounds so the first bytes fully affect the state.
+    for(int i = 0; i < 16; i++) {
+        (void)my_yasmarang();
+    }
 
     return mp_const_none;
 }

--- a/ngu/random.c
+++ b/ngu/random.c
@@ -173,6 +173,12 @@ STATIC mp_obj_t random_reseed(mp_obj_t arg)
     //
     // Accepts a bytes-like object (preferred) or, for backward compatibility
     // with existing callers/tests, a plain integer.
+    //
+    // Ceiling: this generator's independent state is only pad(32) + d(32) +
+    // dat(8) = 72 bits (yasmarang_n is re-derived from pad every step), so it
+    // can retain at most ~72 bits of entropy no matter how many seed bytes are
+    // supplied. Callers needing a full 256-bit margin must not rely on this
+    // PRNG's state alone.
 
     uint8_t tmp[4];
     const uint8_t *p;
@@ -190,6 +196,11 @@ STATIC mp_obj_t random_reseed(mp_obj_t arg)
         tmp[3] = (uint8_t)(v >> 24);
         p = tmp;
         len = sizeof(tmp);
+    }
+
+    if(len == 0) {
+        // reject an empty seed rather than silently performing a no-op reseed
+        mp_raise_ValueError(MP_ERROR_TEXT("empty seed"));
     }
 
     // Sponge-style absorb: fold each byte across the independent state words


### PR DESCRIPTION
### Summary

`random.reseed()` previously assigned only `yasmarang_pad` from a 32-bit-truncated
argument and never touched `yasmarang_n` / `_d` / `_dat`. After a reseed the entire
generator was therefore a function of a single 32-bit word — a 2**32 state space —
with the other state words left at their compile-time constants.

Because `my_random_bytes()` / `random_uint32()` XOR the chip TRNG into every output,
this is a defence-in-depth issue: when the on-chip TRNG is biased or otherwise
untrustworthy, the reseeded Yasmarang state is the only independent entropy, so the
reseed width is the effective security margin.

### Change

- `reseed()` now accepts a bytes-like object and absorbs **every** byte into **all**
  state words (sponge-style, with per-byte diffusion). A plain `int` is still
  accepted for backward compatibility, so existing callers and tests are unaffected.
- `ngu_tests/test_random.py` gains coverage for full-width (digest) seeding.

Note: public RNG output is XOR-masked with the chip TRNG, so the reseeded stream is
not directly observable from Python — the new test guards the interface (that a full
digest is an accepted seed) rather than asserting stream contents.

### Context

Reported publicly by Block's engineering team: "Predictable RNG fallback and 32-bit
reseed in COLDCARD firmware." This PR addresses the reseed-width half; the COLDCARD
firmware side (feeding the full SHA256d digest to `reseed()`) is a companion change.
