### PR TITLE
Reject invalid random byte counts

### DIFF
--- a/ngu/ngu_tests/test_random.py
+++ b/ngu/ngu_tests/test_random.py
@@ -1,6 +1,15 @@
 
 import ngu
 
+assert ngu.random.bytes(0) == b''
+for count in (-1, 4097):
+    try:
+        ngu.random.bytes(count)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError('invalid byte count accepted')
+
 for trial in range(100):
     v = [ngu.random.uint32() for i in range(100)]
     assert len(v) == len(set(v)), 'bad luck, try again'

--- a/ngu/random.c
+++ b/ngu/random.c
@@ -176,8 +176,8 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(random_uniform_obj, random_uniform);
 STATIC mp_obj_t random_bytes(mp_obj_t count_in)
 {
     int count = mp_obj_get_int_truncated(count_in);
-    if(count > 4096) {
-        mp_raise_ValueError(MP_ERROR_TEXT("too many"));
+    if(count < 0 || count > 4096) {
+        mp_raise_ValueError(MP_ERROR_TEXT("out of range"));
     }
 
     vstr_t rv;


### PR DESCRIPTION
Reject `ngu.random.bytes()` counts outside `0..4096` before allocation