### PR TITLE
libbase58: reject over-long decoded payloads in base58_decode_check

### DIFF
--- a/ngu/libbase58.c
+++ b/ngu/libbase58.c
@@ -232,6 +232,10 @@ int base58_decode_check(const char *str, uint8_t *data, int datalen)
 	if (b58tobin(d, &res, str) != true) {
 		return 0;
 	}
+	if (res < 4 || res > datalen + 4) {
+		// decoded size impossible for this buffer; reject before nd underflows
+		return 0;
+	}
 	uint8_t *nd = d + datalen + 4 - res;
 	if (b58check(nd, res, str) < 0) {
 		return 0;


### PR DESCRIPTION
## Summary
`base58_decode_check()` (`external/libngu/ngu/libbase58.c:225`) computes the
payload pointer from the decoded byte count without checking that count is
within the destination buffer:
```c
uint8_t d[datalen + 4];
int res = datalen + 4;
if (b58tobin(d, &res, str) != true) {   // b58tobin writes res = decoded size
    return 0;
}
uint8_t *nd = d + datalen + 4 - res;    // if res > datalen+4, nd < d  (underflow)
if (b58check(nd, res, str) < 0) {       // reads nd[0 .. res-1] via sha256
```
`b58tobin` can legitimately return a decoded size (`res`) **larger** than the
caller-provided buffer (`datalen + 4`). A base58 string of many leading `'1'`
characters does exactly this: every `'1'` contributes a leading zero byte to the
canonical count, and the digit loop is skipped, so
```
res = (datalen+4) - (datalen+4) + zerocount = zerocount = (string length)
```
With a string of ~130+ `'1'`s against the `tmp[120]` buffer used by
`hdnode.c:s_hdnode_deserialize` (or `tmp[128]` in `codecs.c:c_b58decode`), `res`
exceeds `datalen + 4`, so:
- `nd = d + (datalen+4) - res` points **before** the stack buffer `d`, and
- `b58check(nd, res, …)` → `my_dblsha256` → `sha256_single(nd, res-4, …)` reads
  out of bounds (an address below `d`, length `res-4`).
Detected with AddressSanitizer as a `dynamic-stack-buffer-overflow` **read**
(reproduced deterministically at -O0 and -O1).
## Impact
- **Read-only OOB.** The write side of `b58tobin` is correctly bounded by
  `binsz`; this is an information-disclosure / fault primitive, not memory
  corruption. No write, no code execution.
- **Reachability:** any base58-check input the device decodes (xpub /
  descriptor / import strings) that is long and crafted. In practice it faults
  the decode (DoS) or, in the worst case, leaks a few bytes of adjacent stack
  into the checksum comparison. Severity: **low**.
- The existing `datalen > 128` check does **not** help — the overflow is driven
  by `res` (decoded size), which the caller does not control.

## Fix
Reject any decoded size that cannot fit before computing the pointer. A decoded
base58-check payload is always `>= 4` bytes (checksum) and can never exceed the
destination buffer `datalen + 4`:
```c
	if (b58tobin(d, &res, str) != true) {
		return 0;
	}
+	if (res < 4 || res > datalen + 4) {
+		// decoded size impossible for this buffer; reject before nd underflows
+		return 0;
+	}
	uint8_t *nd = d + datalen + 4 - res;
```
A valid payload always satisfies `4 <= res <= datalen + 4`, so the guard rejects
only malformed / hostile inputs and does not change behavior for any legitimate
base58-check string.
## Verification
Patched decoder run over the full `L = 1..600` sweep of `'1'`-only strings under
ASan+UBSan:
```
patched scan 1..600 done, no crash, spurious_decodes=0   (exit 0)
```
- No sanitizer fault across the whole range (the unpatched binary crashes).
- `spurious_decodes=0` — no all-`'1'` string is accepted (the checksum still
  correctly rejects them), confirming the guard does not accidentally admit
  invalid payloads.
- Legitimate base58-check strings (valid xpub/address encodings, `res` well
  under the cap) decode exactly as before — the guard is not on that path.